### PR TITLE
Remove extraneous "

### DIFF
--- a/co2ba.sh
+++ b/co2ba.sh
@@ -50,7 +50,7 @@ printf '%uIFS<>%uTHEN?"Bad Checksum":END\r' $((LINE++)) $SUM
 case "$ACTION" in
 	CALL|EXEC) printf '%u%s%u\r' $((LINE++)) $ACTION $EXE ;;
 	SAVEM|BSAVE) printf '%u?:?"Done. Please type: NEW":%sN$,%u,%u,%u\r' $((LINE++)) $ACTION $TOP $END $EXE ;;
-	*) printf '%uCLS:?"Loaded:":?"top %u":?"end %u":?"exe %u":"?"Please type: NEW"\r' $((LINE++)) $TOP $END $EXE ;;
+	*) printf '%uCLS:?"Loaded:":?"top %u":?"end %u":?"exe %u":?"Please type: NEW"\r' $((LINE++)) $TOP $END $EXE ;;
 esac
 
 # DATA lines


### PR DESCRIPTION
Just a minor fixup for a typo that caused a syntax error.

_____

As an aside: The way you managed to read the binary file using BASH was a delight to read. It never would've occurred to me to do it that way. I'm old fashioned and I'd have done something which required external dependencies, like this to read the 6 byte header:
```bash
 read TOP LEN EXE < <(od -d -N6 -An "$file" )
```
and something like this to sum the rest of the bytes:
```bash
sum=$(od -j6 -t u1 -w1 -v "$file" | awk '{sum+=$2} END{print sum}') 
```
While I tell myself that my way of thinking is fine — it's in the UNIX tradition of tools that work together — I want to give respect for what I recognize is an elegant use of pure BASH. Kudos!